### PR TITLE
Fix 3-digit color codes

### DIFF
--- a/n-hud.lua
+++ b/n-hud.lua
@@ -20,15 +20,21 @@ local function convert_color(text)
         return nil
     end
     text = text:sub(3, -2)
-    local rstring = text:sub(1, 2) or "ff"
-    local gstring = text:sub(3, 4) or "ff"
-    local bstring = text:sub(5, 6) or "ff"
-    local astring = text:sub(7, 8) or "ff"
+    local rstring, gstring, bstring = "", "", ""
+    if text:len() ~= 3 and text:len() ~= 6 then return 255, 255, 255, 255 end
+    if text:len() == 6 then
+        rstring = text:sub(1, 2) or "ff"
+        gstring = text:sub(3, 4) or "ff"
+        bstring = text:sub(5, 6) or "ff"
+    else
+        rstring = text:sub(1, 1) .. text:sub(1, 1)
+        gstring = text:sub(2, 2) .. text:sub(2, 2)
+        bstring = text:sub(3, 3) .. text:sub(3, 3)
+    end
     local r = tonumber("0x" .. rstring) or 255
     local g = tonumber("0x" .. gstring) or 255
     local b = tonumber("0x" .. bstring) or 255
-    local a = tonumber("0x" .. astring) or 255
-    return r, g, b, a
+    return r, g, b, 255
 end
 
 ---@param text string


### PR DESCRIPTION
Changes the convert_color function to support 3-digit color codes (such as #f8f). CoopDX has supported them for a while now, and I implemented this change in my other mods a long time ago. Sorry for not doing this sooner!