### PR TITLE
Update menu position when setting current character through API

### DIFF
--- a/o-api.lua
+++ b/o-api.lua
@@ -478,6 +478,7 @@ end
 local function character_set_current_number(charNum)
     if type(charNum) ~= TYPE_INTEGER or characterTable[charNum] == nil then return end
     currChar = charNum
+    currCharRender = charNum
     charBeingSet = true
 end
 


### PR DESCRIPTION
Small fix for the [issue](https://github.com/Squishy6094/character-select-coop/issues/25) with menu position not updating when setting current character through the API function `character_set_current_number()`. 