### PR TITLE
Require config_character_sounds() to hook the character sound function

### DIFF
--- a/z-voice.lua
+++ b/z-voice.lua
@@ -354,4 +354,10 @@ local function on_play_sound(soundbits,pos)
     end
 end
 
+local function waluigi_char_sound(m, sound, pos)
+    if charSelect.character_get_current_number(m.playerIndex) == 3 then
+        return custom_character_sound(m, sound, pos)
+    end
+end
+hook_event(HOOK_CHARACTER_SOUND, waluigi_char_sound)
 hook_event(HOOK_ON_PLAY_SOUND, on_play_sound) --	Called when a sound is going to play, return a SOUND_* constant or NO_SOUND to override the sound


### PR DESCRIPTION
This gives character creators a little more freedom over how and when custom voicelines are played if they choose not to use the config_character_sounds() and instead run _G.charSelect.voice.sound() directly. Noticed a couple voice-related things with my own CS mod breaking because of the change, so I was hoping it could be reverted.