### PR TITLE
character_add_voice hook fix

### DIFF
--- a/z-api.lua
+++ b/z-api.lua
@@ -279,7 +279,7 @@ local function character_add_voice(modelInfo, clips)
                         if load ~= nil then
                             voiceTable[voice][i] = load
                         end
-                        nd
+                    end
                 end
             end
         end


### PR DESCRIPTION
Hooks the function after it finishes instead of calling the hook (HOOK_ON_MODS_LOADED) inside the function
(And then also re-aligned the function)