### PR TITLE
fix for character_add_ending_toad_model infinite loop

### DIFF
--- a/z-api.lua
+++ b/z-api.lua
@@ -476,12 +476,16 @@ end
 local function character_add_ending_toad_model(modelInfo, toadModelRight, toadModelLeft)
     local settingRightToad = false
     character_add_model_replacement(character_get_number_from_model(modelInfo), id_bhvEndToad, function (o)
-        -- Only difference between the two objects is positions
-        settingRightToad = not settingRightToad
-        if settingRightToad then
-            return toadModelRight
+        if (obj_has_model_extended(o,toadModelRight) == 0) and (obj_has_model_extended(o,toadModelLeft) == 0)  then --if the model was already changed
+            settingRightToad = not settingRightToad
+            if settingRightToad then
+                return toadModelRight
+            end
+            return toadModelLeft
+        else --the ending toads model was already changed
+            return obj_get_model_id_extended(o)
         end
-        return toadModelLeft
+        
     end)
 end
 


### PR DESCRIPTION
  After this commit Squishy6094/character-select-coop@1853712. The function character_add_ending_toad_model never uses toadModelRight due to ending cutscene toads being at 0,0,0 when the code is ran. This is a  fix to character_add_ending_toad_model to use toadModelRight instead of ignoring it. and just using toadModelLeft.