### PR TITLE
fix obj_set_model_extended for other mods

### DIFF
--- a/z-api.lua
+++ b/z-api.lua
@@ -1301,8 +1301,8 @@ local function obj_set_model_extended(obj, modelInfo)
     for i = 0, MAX_PLAYERS - 1 do
         if gMarioStates[i].marioObj == obj then
             log_to_console_once("Character Select: Mario Object cannot be changed with 'obj_set_model_extended' while Character Select is Active, please use 'character_edit'!!", CONSOLE_MESSAGE_WARNING)
+            return
         end
-        return
     end
     return obj_set_model_extended_original(obj, modelInfo)
 end


### PR DESCRIPTION
Before this commit , obj_set_model_extended_original wasn't used due to the function always returning on the first pass of the for loop regardless if the object was a mario object or not. Causing other mods to be unable to change object models using obj_set_model_extended. This commit fixes that by making it only return if the object is a mario object.